### PR TITLE
Make charter more explicit about composability and unsigned_varint dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,41 @@
 # IETF Multiformats Working Group
 
 Multiformats are a collection of self-describing data formats that consist of an
-inline data header and a data value. Multiformats have binary and text-based
-representations and are used to express base encodings (multibase),
-cryptographic hashes (multihash), cryptographic keys (multikey), network
-addresses (multiaddr), and a variety of other binary serialization formats
-(multicodec).
+inline data header and a data value. They are composable in that some of the
+more complex forms take another multiformat header/value tuple as value,
+recursively. Multiformats are designed to compose into binary streams with both
+header values and data values expressed in unsigned varints (a slight variation
+from protobuf varints and the UNIX LEB128 standard), with the exception of
+multibase, which wraps any valid binary multiformat in a base-encoding and
+prepends its header in the target encoding rather than to the binary data value.
+The unsigned varint-based binary multiformats include headers for cryptographic
+hashes (multihash), cryptographic keys (multikey), network addresses
+(multiaddr), and a variety of other binary serialization formats that do not
+meet all the requirements to form part of the above registries (the rest of the
+multicodec entries).
 
 The scope of this Working Group is to discuss these formats as they relate to
 standardization at the IETF. Specifically, the group is currently focused on the
-standardization of two Multiformats: Multibase and Multihash. The input
-documents for these two Multiformats are:
+standardization of the two most generally-useful Multiformats: Multibase and
+Multihash. The input documents for these two Multiformats are:
 
 * https://datatracker.ietf.org/doc/draft-multiformats-multibase/
 * https://datatracker.ietf.org/doc/draft-multiformats-multihash/
 
 Outputs for the group will be:
 
-* A Multibase specification
-* A Multihash specification
-* A registry for Multiformats with initial entries for Multibase and Multihash
+1. An RFC defining the unsigned varint primitive 
+2. An RFC defining a registry-group for all the Multiformats, empty at
+   inception, with registration process and group-wide constraints on
+   registration values
+3. An RFC defining the Multibase registry within the above group, empty at
+   inception
+4. A Multibase specification which populates the above with currently-stable
+   and implemented registrations
+5. An RFC defining the Multihash registry within the above group, empty at
+   inception
+6. A Multihash specification which populates the above with currently-stable
+   and implemented registrations
 
 The outputs from this Working Group are currently being used by various groups,
 including the W3C Verifiable Credentials Working Group, W3C Decentralized

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ more complex forms take another multiformat header/value tuple as value,
 recursively. Multiformats are designed to compose into binary streams with both
 header values and data values expressed in unsigned varints (a slight variation
 from protobuf varints and the UNIX LEB128 standard), with the exception of
-multibase, which wraps any valid binary multiformat in a base-encoding and
-prepends its header in the target encoding rather than to the binary data value.
-The unsigned varint-based binary multiformats include headers for cryptographic
-hashes (multihash), cryptographic keys (multikey), network addresses
-(multiaddr), and a variety of other binary serialization formats that do not
-meet all the requirements to form part of the above registries (the rest of the
-multicodec entries).
+multibase, which base-encodes any valid binary multiformat and prepends its
+header to the target encoding rather than to the binary data value. The unsigned
+varint-based binary multiformats include headers for cryptographic hashes
+(multihash), cryptographic keys (multikey), network addresses (multiaddr), and a
+variety of other binary serialization formats that do not meet all the
+requirements to form part of the above registries (the rest of the
+[multicodec][1] entries).
 
 The scope of this Working Group is to discuss these formats as they relate to
 standardization at the IETF. Specifically, the group is currently focused on the
@@ -28,14 +28,14 @@ Outputs for the group will be:
 2. An RFC defining a registry-group for all the Multiformats, empty at
    inception, with registration process and group-wide constraints on
    registration values
-3. An RFC defining the Multibase registry within the above group, empty at
-   inception
-4. A Multibase specification which populates the above with currently-stable
-   and implemented registrations
-5. An RFC defining the Multihash registry within the above group, empty at
-   inception
-6. A Multihash specification which populates the above with currently-stable
-   and implemented registrations
+3. An RFC defining the Multibase registry within the Multiformats registry
+   group, empty at inception
+4. A Multibase specification which populates the above with currently-stable and
+   implemented registrations
+5. An RFC defining the Multihash registry within the Multiformats registry
+   group, empty at inception
+6. A Multihash specification which populates the above with currently-stable and
+   implemented registrations
 
 The outputs from this Working Group are currently being used by various groups,
 including the W3C Verifiable Credentials Working Group, W3C Decentralized
@@ -54,3 +54,5 @@ Items that are out of scope for the group include:
 * Determining whether one data format is better than another data format.
 * Changing current Multiformat header assignments in a way that breaks backward
   compatibility with production deployments.
+
+[1]: https://ipfs.io/ipfs/QmXec1jjwzxWJoNbxQF5KffL8q6hFXm9QwUGaa3wKGk6dT/#title=Multicodecs&src=https://raw.githubusercontent.com/multiformats/multicodec/master/table.csv

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ more complex forms take another multiformat header/value tuple as value,
 recursively. Multiformats are designed to compose into binary streams with both
 header values and data values expressed in unsigned varints (a slight variation
 from protobuf varints and the UNIX LEB128 standard), with the exception of
-multibase, which base-encodes any valid binary multiformat and prepends its
+multibase, which base-encodes any binary and prepends its
 header to the target encoding rather than to the binary data value. The unsigned
 varint-based binary multiformats comprising the rest of the [multicodec][1]
 table include headers for cryptographic hashes (multihash), cryptographic keys

--- a/README.md
+++ b/README.md
@@ -3,38 +3,32 @@
 Multiformats are a collection of self-describing data formats that consist of an
 inline data header and a data value. They are composable in that some of the
 more complex forms take another multiformat header/value tuple as value,
-recursively. Multiformats are designed to compose into binary streams with both
-header values and data values expressed in unsigned varints (a slight variation
-from protobuf varints and the UNIX LEB128 standard), with the exception of
-multibase, which base-encodes any binary and prepends its
-header to the target encoding rather than to the binary data value. The unsigned
-varint-based binary multiformats comprising the rest of the [multicodec][1]
-table include headers for cryptographic hashes (multihash), cryptographic keys
-(multikey), network addresses (multiaddr), as well as a handful of vendor and
-experimental registrations for interoperability purposes.
+recursively. Multiformats are designed to compose data into binary streams with
+both inline header values (called [multicodecs][1]) and corresponding data
+values, with the exception of multibase, which base-encodes any binary and
+prepends its inline header to the target encoding rather than to the binary data
+value being encoded.
 
 The scope of this Working Group is to discuss these formats as they relate to
-standardization at the IETF. Specifically, the group is currently focused on the
-standardization of the two most generally-useful Multiformats: Multibase and
-Multihash. The input documents for these two Multiformats are:
+standardization at the IETF for wider and safer usage. Specifically, the group
+is currently focused on the standardization of the two most generally-useful
+multiformats: multibase and multihash. The input documents for these two
+multiformats are:
 
 * https://datatracker.ietf.org/doc/draft-multiformats-multibase/
 * https://datatracker.ietf.org/doc/draft-multiformats-multihash/
 
 Outputs for the group will be:
 
-1. An RFC defining the unsigned varint primitive 
-2. An RFC defining a registry-group for all the Multiformats, empty at
+1. An RFC specifying multibase usage
+2. An RFC defining an independent multibase registry and populating it with
+   today's already-implemented stable and final values
+3. An RFC defining a registry-group for all the multicodecs, empty at
    inception, with registration process and group-wide constraints on
    registration values
-3. An RFC defining the Multibase registry within the Multiformats registry
-   group, empty at inception
-4. A Multibase specification which populates the above with currently-stable and
-   implemented registrations
-5. An RFC defining the Multihash registry within the Multiformats registry
-   group, empty at inception
-6. A Multihash specification which populates the above with currently-stable and
-   implemented registrations
+4. An RFC specifying multihash usage
+5. An RFC defining a multihash registry within the multicodecs registry group
+   and populating it with today's already-implemented stable and final values
 
 The outputs from this Working Group are currently being used by various groups,
 including the W3C Verifiable Credentials Working Group, W3C Decentralized
@@ -47,11 +41,12 @@ listed in this section as well as other relevant groups as the work progresses.
 
 Items that are out of scope for the group include:
 
-* Standardizing Multiformats that are not explicitly listed in the charter.
-* Creating or standardizing new data formats identified by a Multiformat byte
+* Standardizing other multiformats that are not explicitly listed in the
+  charter.
+* Creating or standardizing new data formats identified by a multicodec byte
   header.
 * Determining whether one data format is better than another data format.
-* Changing current Multiformat header assignments in a way that breaks backward
+* Changing current multiformat header assignments in a way that breaks backward
   compatibility with production deployments.
 
 [1]: https://ipfs.io/ipfs/QmXec1jjwzxWJoNbxQF5KffL8q6hFXm9QwUGaa3wKGk6dT/#title=Multicodecs&src=https://raw.githubusercontent.com/multiformats/multicodec/master/table.csv

--- a/README.md
+++ b/README.md
@@ -8,11 +8,10 @@ header values and data values expressed in unsigned varints (a slight variation
 from protobuf varints and the UNIX LEB128 standard), with the exception of
 multibase, which base-encodes any valid binary multiformat and prepends its
 header to the target encoding rather than to the binary data value. The unsigned
-varint-based binary multiformats include headers for cryptographic hashes
-(multihash), cryptographic keys (multikey), network addresses (multiaddr), and a
-variety of other binary serialization formats that do not meet all the
-requirements to form part of the above registries (the rest of the
-[multicodec][1] entries).
+varint-based binary multiformats comprising the rest of the [multicodec][1]
+table include headers for cryptographic hashes (multihash), cryptographic keys
+(multikey), network addresses (multiaddr), as well as a handful of vendor and
+experimental registrations for interoperability purposes.
 
 The scope of this Working Group is to discuss these formats as they relate to
 standardization at the IETF. Specifically, the group is currently focused on the


### PR DESCRIPTION
Note: this PR was made on the basis of conversations with various implementers and code-maintainers to refine how the IETF versions of these registries could be more explicit about the inter-dependencies between multiformats qua registry group.